### PR TITLE
Support Go Modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/writeas/impart
+
+go 1.9


### PR DESCRIPTION
Hello,

Please consider supporting [Go Modules], the new packaging standard that will be adopted fully in Go 1.12. Experimental support is in Go 1.11 and the new module paths are supported in Go 1.9.7+ and Go 1.10.3+ in a read-only manner for backwards compatibility with all supported versions of Go (although the import path doesn't change with this library, so it doesn't matter much here).

Because this library has no external dependencies and is still below version 2, the `go.mod` file is fairly simple. The only other thing that would need to be done is to create a semver compatible tag after this patch is merged (eg. v1.0.1) to allow other things to pin to that version without having to use the special commit-based version string.

Also: I notice that the various write.as packages are a bit inconsistent in how and where they live. Eg. `go-writeas` uses a self-hosted gopkg.in and has an import path at code.write.as, this package has a GitHub import, and still others use a code.as import. Is there something you plan to standardize on? Modules make the gopkg.in style imports unnecessary (it might even be broken, I'm not sure), but otherwise it's probably best to decide what the final import path will be before setting it in a module (EDIT: if you prefer to have things on a domain that you control and is distinct from the source repo's domain, there's also the option of using a meta tag which `go get` understands to redirect from whatever domain you choose). 

Thank you for your consideration.

[Go Modules]: https://github.com/golang/go/wiki/Modules